### PR TITLE
Health checking and various cleanups

### DIFF
--- a/cpp/BCPs/target/target.cpp
+++ b/cpp/BCPs/target/target.cpp
@@ -141,6 +141,9 @@ std::string state_map(int state)
 
 int main(int argc, char * argv[])
 {
+  // constants
+  float pi = 3.14159;
+  float pi2 = pi * 2.0;
   hirez_timer returntime();
   // load the global configuration
   conf_reader config;
@@ -209,9 +212,9 @@ int main(int argc, char * argv[])
           << "\n\t           State: " << state_map(state) 
           << "\n\t vct from center: " << (current.location-center).to_polar()
           << "\n\t    ground speed: " << current.velocity.magnatude()
-          << "\n\t vehicle heading: " << current.attitude.z 
+          << "\n\t vehicle heading: " << [&]{ return fmod((current.attitude.z + pi2),pi2);}()
           << "\n\t   actual motion: " << 
-            [&]{triplet t=current.velocity; t.z=0.0; return t.to_polar().y;}()
+            [&]{triplet t=current.velocity; t.z=0.0; return fmod(t.to_polar().y+pi2,pi2);}()
           << "\n\t calc'd way home: " << wayhome
           << endl;
       };

--- a/cpp/sim_engine/bcp_server/bcp_server.cpp
+++ b/cpp/sim_engine/bcp_server/bcp_server.cpp
@@ -83,7 +83,8 @@ void bcp_listener::processor()
       {
         log.trace("new connection");
         triplet l(u(rng)-1e4,u(rng)-1e4,0.0);
-        engine.add_object(object_p(new bot_mk1(std::move(bcp), l)));     
+//        engine.add_object(object_p(new bot_mk1(std::move(bcp), l)));     
+        engine.add_object(std::make_shared<bot_mk1>(std::move(bcp), l));     
         log.trace("bot added to sim");
       }
       else 

--- a/cpp/sim_engine/bcp_server/bcp_server.cpp
+++ b/cpp/sim_engine/bcp_server/bcp_server.cpp
@@ -44,12 +44,12 @@ void bcp_listener::start()
 void bcp_listener::stop()
 {
   try { listener.stop_listen(); } catch (...) {};
-  p_thread.join();
+  if (p_thread.joinable()) p_thread.join();
 };
 
 bool bcp_listener::listening()
 {
-  return listener.listening();
+  return listener.listening() and p_thread.joinable();
 };
 
 int bcp_listener::connections()
@@ -83,7 +83,6 @@ void bcp_listener::processor()
       {
         log.trace("new connection");
         triplet l(u(rng)-1e4,u(rng)-1e4,0.0);
-//        engine.add_object(object_p(new bot_mk1(std::move(bcp), l)));     
         engine.add_object(std::make_shared<bot_mk1>(std::move(bcp), l));     
         log.trace("bot added to sim");
       }

--- a/cpp/sim_engine/bcp_server/bcp_server_test.cpp
+++ b/cpp/sim_engine/bcp_server/bcp_server_test.cpp
@@ -69,7 +69,7 @@ int main()
     sim_core::report rep = msg->data<sim_core::report>();
     cout << rep.quanta << "\t" << rep.objects.size() << "\t";
     for (auto p : rep.objects)
-      cout << p.first << " ";
+      cout << split(p,':')[0] << " ";
     cout << endl;
     count = rep.objects.size();
   };

--- a/cpp/sim_engine/bot_mk1/bot_mk1.cpp
+++ b/cpp/sim_engine/bot_mk1/bot_mk1.cpp
@@ -141,7 +141,7 @@ void bot_mk1::receiver()
       s = gsub(gsub(s,"\n",""),"\r","");
       if (s.length() > 0)
       {  
-        log.trace("<< "+s);
+//        log.trace("<< "+s);
         from_BCP.push(s);
       };
     };
@@ -161,7 +161,7 @@ void bot_mk1::transmitter()
     {
       std::string s = to_BCP.pop();
       BCP->put(s+"\r");
-      log.trace(">> "+s);
+//      log.trace(">> "+s);
     };
   }
   catch (...)
@@ -240,7 +240,7 @@ void bot_mk1::send_to_bcp(std::string msg)
 void bot_mk1::bot_cmd(std::string cmd)
 {
   auto log(common_log::get_reference()(name));
-  log.trace("++ "+cmd);
+//  log.trace("++ "+cmd);
   from_BCP.push(cmd);
 };
 

--- a/cpp/sim_engine/main/simengine.cpp
+++ b/cpp/sim_engine/main/simengine.cpp
@@ -71,7 +71,7 @@ void output_writer(string id, string host, bool write_zeros=true)
         mongo::BSONArrayBuilder obj_array;
         for (auto o : rep.objects)
         {
-          obj_array << o.second->as_str();
+          obj_array << o;
           //o.second->as_str());
         };
         b.appendArray("objects",obj_array.arr());

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -89,7 +89,7 @@ sim_core::report sim_core::get_report(unsigned long long ticks, double wt)
   returnme.quanta = quanta;
   returnme.duration = ticks;
   returnme.wallclock = wt;
-  returnme.objects = get_obj_copies();
+  returnme.objects = obj_status();
   return returnme;
 };
 

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -370,7 +370,7 @@ void sim_core::start_sim()
 
 bool sim_core::running()
 {
-  return is_running;
+  return engine.joinable();
 };
 
 

--- a/cpp/sim_engine/sim_core/sim_core.h
+++ b/cpp/sim_engine/sim_core/sim_core.h
@@ -121,7 +121,7 @@ public:
     unsigned long long quanta;
     unsigned long long duration;
     double wallclock;
-    object_list objects;
+    strlist objects;
   };
   /****************************************
    * The following methods are exposed for 
@@ -134,7 +134,7 @@ public:
   object_list get_obj_copies();
 private:
   /****************************************
-  * clsn_rec is used to track interseting
+  * clsn_rec is used to track intersecting
   * objects.
   ***************************************/
   struct clsn_rec


### PR DESCRIPTION
1. Added process health monitoring to the main execution thread. sim_core, bcp_server (the TCP listener) and the sim output writer are checked every 100 ms. If any of those processes have failed, simengine will shut down as gracefully as possible.
2. Hooked the SIGINT handler to catch control-c and execute a graceful shutdown. This replaces the old "press any key to exit" process.
3. Reworked the "fixed duration run" handling to fit within the new health monitoring loop. In previous versions, you could do a fixed duration run, or one which you killed at whim, but not both at the same time. The new setup will properly shutdown based on control-c, timeout, or health issues, whichever comes first.
4.  Altered sim_core reporting to avoid the expensive clone operation; instead it now passes on the the as_str() representation of each object; this reduces memory allocation and processing time as compared to the older clone all objects method. This made absolutely no difference for the actual output to mongo, as the writer thread was getting and using the as_str() representation of the clones there. Cheaper, faster, better... a clear win.
5. Commented out BCP command traffic logging in bot_mk1. This will probably be made configurable later, as it's nice for debugging, but it can lead to over 17gb of logs for a 2 hour 50 bot run. It had to go.
6. Misc cleanups to improve stability.