### PR TITLE
Rewrite -- small cleanups on collision checking, etc.

### DIFF
--- a/cpp/sim_engine/main/simengine.cpp
+++ b/cpp/sim_engine/main/simengine.cpp
@@ -90,7 +90,7 @@ void output_writer(string id, string host, bool write_zeros=true)
     };
   }
   catch (...) {}; 
-  cout << "output writer closed." << endl;
+  cout << "  Output writer closed." << endl;
 };
 
 string mk_run_id()
@@ -216,15 +216,19 @@ int main(int argc, char * argv[])
   // shut it all down.
   cout << "shutting down" << endl;
   bcps.stop();
+  cout << "  BCP Listener stopped." << endl;
   world.stop_sim();
+  cout << "  simulation stopped." << endl;
   // wait for output queue to drain.
   chrono::milliseconds pause(100);
   while (soq.size()) this_thread::sleep_for(pause);
-  // close out the writer.
+  cout << "  Output queue empty." << endl;
+    // close out the writer.
   soq.shutdown();
   if (writer.joinable()) writer.join();
+  cout << "  Output writer stopped." << endl;
   // say goodbye
-  g_log.info("Shut down");
+  g_log.info("Shutdown complete.");
   exit(0);
 };
 

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -155,11 +155,13 @@ sim_core::clsn_rec sim_core::check_one(object_p a, object_p b, float duration)
     returnme.a = a;
     returnme.b = b;
   };
+  return returnme;
 };
 
 void sim_core::collision_check()
 {
   // this version is using a very naive algorithm.
+  float cr = 15000 * quanta_duration;
   auto b = all_objects.begin();
   auto c = b;
   auto e = all_objects.end();
@@ -169,19 +171,23 @@ void sim_core::collision_check()
     b++;
     while (b != e)
     {
-      if (c->second->check_collision(b->second, quanta_duration))
+      auto &o1 = c->second;
+      auto &o2 = b->second;
+      float d = o1->location.range(o1->location)
+                - o1->bounding_sphere.radius - o2->bounding_sphere.radius;
+      if ((d<cr) and  o1->check_collision(o2,quanta_duration))
       {
         // a collision has been found.
         clsn_rec crec;
-        crec.a = c->second;
-        crec.b = b->second;
+        crec.a = o1;
+        crec.b = o2;
         collisions.push_back(crec);
       };
       b++;
     };
     c++;
   };
-  // at exit, all colliions have been recorded.
+  // at exit, all collisions have been recorded.
 };
 
 void sim_core::turn_init()

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -146,9 +146,15 @@ void sim_core::tick()
 * designed to be called by sim_core::collision_check as
 * a future function.
 *****************/
-sim_core::clsn_rec check_one()
+sim_core::clsn_rec sim_core::check_one(object_p a, object_p b, float duration)
 {
-  //TODO: Complete this function.
+  clsn_rec returnme;
+  returnme.a = NULL;
+  if (a->check_collision(b, duration))
+  {
+    returnme.a = a;
+    returnme.b = b;
+  };
 };
 
 void sim_core::collision_check()

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -139,6 +139,18 @@ void sim_core::tick()
   // collision resolution. They may be several states at once.
 };
 
+
+/*****************
+* check_one() returns a valid clsn_rec if a collision
+* was detected, or one with null pointers if not. it's 
+* designed to be called by sim_core::collision_check as
+* a future function.
+*****************/
+sim_core::clsn_rec check_one()
+{
+  //TODO: Complete this function.
+};
+
 void sim_core::collision_check()
 {
   // this version is using a very naive algorithm.

--- a/cpp/sim_engine/sim_core/sim_core.cpp
+++ b/cpp/sim_engine/sim_core/sim_core.cpp
@@ -350,8 +350,10 @@ void sim_core::remove_obj(long long unsigned int oid)
 void sim_core::stop_sim()
 {
   end_run = true;
-  if (engine.joinable())
+  if (engine.joinable()) 
+  {
     engine.join();
+  };
 };
 
 void sim_core::start_sim()

--- a/cpp/sim_engine/sim_core/sim_core.h
+++ b/cpp/sim_engine/sim_core/sim_core.h
@@ -163,6 +163,7 @@ private:
   // these methods implement simulation steps.
   void turn_init();
   void tick();
+  clsn_rec check_one(object_p a, object_p b, float duration);
   void collision_check();
   void resolve_collisions();
   // Stores the current state to the "sim_output" ipc_queue

--- a/cpp/sim_engine/sim_core/sim_core.h
+++ b/cpp/sim_engine/sim_core/sim_core.h
@@ -163,7 +163,7 @@ private:
   // these methods implement simulation steps.
   void turn_init();
   void tick();
-  clsn_rec check_one(object_p a, object_p b, float duration);
+  static clsn_rec check_one(object_p a, object_p b, float duration);
   void collision_check();
   void resolve_collisions();
   // Stores the current state to the "sim_output" ipc_queue
@@ -177,4 +177,4 @@ typedef singleton<sim_core> global_sim_core;
   
 } // namepace nrtb
 
-#endif // sim_core_heade
+#endif // sim_core_header

--- a/cpp/sim_engine/sim_core/sim_core_test.cpp
+++ b/cpp/sim_engine/sim_core/sim_core_test.cpp
@@ -381,7 +381,7 @@ int main()
   while (w3.running()) usleep(50);
   for (auto o : w3.get_obj_copies())
     cout << o.second->as_str() << endl;
-  // verify ending count (all should have been distroyed.
+  // verify ending count (all should have been destroyed.
   t = log_test(log,"Collision test", (w3.obj_status().size()));
   failed = failed or t;
     

--- a/cpp/sim_engine/sim_core/sim_core_test.cpp
+++ b/cpp/sim_engine/sim_core/sim_core_test.cpp
@@ -345,7 +345,7 @@ int main()
   w2.start_sim();
   sleep(3);
   w2.stop_sim();
-  // verify ending count (all should have been distroyed.
+  // verify ending count (all should have been destroyed.
   t = log_test(log,"50/50 end count", (w2.obj_status().size()));
   failed = failed or t;
   


### PR DESCRIPTION
This code has a currently unused sim_core method which will be used when we actually complete making parallel collision checking. in the meanwhile, collision checking is about 10% of quanta calculation time, and we are well under times at 50hz.
The cleanups are harmless and worth keeping, so in the master branch they go.