### PR TITLE
Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Session.vim
 .project
 RemoteSystemsTempFiles
 nrtb_beta.kdev4
+
+### VS Code ###
+.vscode
+

--- a/cpp/common/abs_queue/abs_queue_test.cpp
+++ b/cpp/common/abs_queue/abs_queue_test.cpp
@@ -41,7 +41,8 @@ int consumer_task(string name, queue_p input)
     {
       int num = input->pop();
       count++;
-      usleep(1);	  
+      usleep(1);
+      input->task_done();	  
     }
   }
   catch (...) 
@@ -110,7 +111,10 @@ int main()
   {
     q1->push(i);
   };
-  while (q1->size()) usleep(100);
+  //while (q1->size()) usleep(100);
+  cout << "join() test : " << flush;
+  q1->join();
+  cout << "PASSED" << endl;
   // shut it all down
   q1->shutdown();
   // important numbers


### PR DESCRIPTION
Added useful functionality to abs_queue, and therefore to all queue descendents. Changes to not affect current use in any way, but add the ability to join on the queue until all items are processed if the workers report completion appropriately.

Tested and ready to go.