### PR TITLE
Rewrite: Sim-core multi-threading, improved stability and cleanups

### DIFF
--- a/cpp/sim_engine/base_object/base_object.cpp
+++ b/cpp/sim_engine/base_object/base_object.cpp
@@ -198,6 +198,7 @@ bool base_object::tick(float quanta)
                         torque.angles(),quanta);
     rotation_mod.set((rotation.angles() + rbase.angles()) / 2.0);
   }
+  alive != killme;
   return killme;
 };
 
@@ -213,6 +214,7 @@ bool base_object::apply(float quanta)
   for (auto e : post_attribs)
     if (e.second->tick(*this, quanta))
       killme = true;
+  alive != killme;
   return killme;
 };
 

--- a/cpp/sim_engine/base_object/base_object.h
+++ b/cpp/sim_engine/base_object/base_object.h
@@ -168,7 +168,7 @@ public:
  **********************************************/
 struct base_object
 {
-  bool alive {false};
+  bool alive {true};
   // provides a unique sequence of id numbers for objects.
   static serializer object_num;
   // NOP destructor to ensure clean deallocation.

--- a/cpp/sim_engine/base_object/base_object.h
+++ b/cpp/sim_engine/base_object/base_object.h
@@ -168,6 +168,7 @@ public:
  **********************************************/
 struct base_object
 {
+  bool alive {false};
   // provides a unique sequence of id numbers for objects.
   static serializer object_num;
   // NOP destructor to ensure clean deallocation.

--- a/cpp/sim_engine/bcp_server/bcp_server_test.cpp
+++ b/cpp/sim_engine/bcp_server/bcp_server_test.cpp
@@ -40,7 +40,7 @@ int main()
 
   // use the listener to make some bots.
   sim_core sc1(1.0/50.0);
-  sc1.start_sim();
+  sc1.start_sim(2);
   bcp_listener listener(sc1,"*:64500",100);
   listener.start();
   std::vector<tcp_socket_p> bcps;

--- a/cpp/sim_engine/main/simengine.cpp
+++ b/cpp/sim_engine/main/simengine.cpp
@@ -167,7 +167,7 @@ int main(int argc, char * argv[])
   float quanta = config.get<float>("quanta",1.0/50.0); 
   sim_core & world = global_sim_core::get_reference();
   world.set_quanta(quanta);
-  world.start_sim();
+  world.start_sim(std::thread::hardware_concurrency());
   
   // start the bcp_server
   bcp_listener bcps(world,
@@ -183,7 +183,7 @@ int main(int argc, char * argv[])
   cout << "\nUse Control-C to manually exit" << endl;
   signal (SIGINT, sig_int_handler);
 
-  // Run health check loop unitl failure or requested shutdown.
+  // Run health check loop until failure or requested shutdown.
   bool done{false};
   long long int tock_limit = run_time * 10;
   long long int tocks = 0;

--- a/cpp/sim_engine/radar/radar_mk1_test.cpp
+++ b/cpp/sim_engine/radar/radar_mk1_test.cpp
@@ -99,7 +99,7 @@ int main()
   
   // start a sim_core;
   sim_core & w = global_sim_core::get_reference();
-  w.start_sim();
+  w.start_sim(2);
   chrono::milliseconds nap(10);
   //while (!w.running()) this_thread::sleep_for(nap); 
   

--- a/cpp/sim_engine/sim_core/sim_core.h
+++ b/cpp/sim_engine/sim_core/sim_core.h
@@ -103,7 +103,7 @@ public:
   // returns the current population count
   int size();
   // Starts the simulation. Throws if already running.
-  void start_sim();
+  void start_sim(int threads);
   // Stops the the simulation. 
   void stop_sim();
   // Inserts the object into the simulation.
@@ -171,6 +171,14 @@ private:
   report get_report(unsigned long long ticks, double wt);
   // The actual simulation engine.. runs as a seperate thread.
   static void run_sim(sim_core & w);
+  /***************************
+   * Changes for parallel update processing.
+   ****************************/
+  typedef linear_queue<object_p> object_q;
+  object_q ticklist;
+  object_q applylist;
+  static void do_tick(sim_core & w);
+  static void do_apply(sim_core & w);  
 };
 
 typedef singleton<sim_core> global_sim_core;

--- a/cpp/sim_engine/sim_core/sim_core.h
+++ b/cpp/sim_engine/sim_core/sim_core.h
@@ -170,15 +170,16 @@ private:
   //  in a gp_sim_message with report struct as the data.
   report get_report(unsigned long long ticks, double wt);
   // The actual simulation engine.. runs as a seperate thread.
-  static void run_sim(sim_core & w);
+  void run_sim();
   /***************************
    * Changes for parallel update processing.
    ****************************/
+  int worker_count {2};
   typedef linear_queue<object_p> object_q;
   object_q ticklist;
   object_q applylist;
-  static void do_tick(sim_core & w);
-  static void do_apply(sim_core & w);  
+  void do_tick();
+  void do_apply();  
 };
 
 typedef singleton<sim_core> global_sim_core;

--- a/cpp/sim_engine/sim_core/sim_core_test.cpp
+++ b/cpp/sim_engine/sim_core/sim_core_test.cpp
@@ -235,6 +235,7 @@ val_map get_sim_metrics()
 int main()
 {
   bool failed = false;
+  int tcount = std::thread::hardware_concurrency();
     
   log_recorder log(common_log::get_reference()("sim_core_test"));
   log.trace("Starting");
@@ -256,7 +257,7 @@ int main()
   failed = failed or t; 
   
   cout << "Single object run (3 secs)" << endl;
-  world.start_sim();
+  world.start_sim(tcount);
   t = log_test(log,"sim_core::start_sim() returned",false);
   failed = failed or t;
   // run 3 and running test.
@@ -294,7 +295,7 @@ int main()
 
   cout << "Dynamic add test (0.3 secs)" << endl;
   sim_core w1(1/50.0);
-  w1.start_sim();
+  w1.start_sim(tcount);
   while (!(w1.running())) usleep(10);
   usleep(1e5);
   contacts l1 = w1.contact_list();
@@ -342,7 +343,7 @@ int main()
   // verify starting count
   t = log_test(log,"50/50 start count", (w2.obj_status().size()!=50));
   failed = failed or t;
-  w2.start_sim();
+  w2.start_sim(tcount);
   sleep(3);
   w2.stop_sim();
   // verify ending count (all should have been destroyed.
@@ -375,7 +376,7 @@ int main()
   object_p target(new my_object);
   target->location.y = 0.75;
   w3.add_object(target);
-  w3.start_sim();
+  w3.start_sim(tcount);
   sleep(1);
   w3.stop_sim();
   while (w3.running()) usleep(50);


### PR DESCRIPTION
Initial cut at parallelization of the sim-core, with thread pools working the tick and apply portions of the quanta resolution. It's a little faster, but a lot more stable under heavy load.  This is more than stable enough for use, and forms a solid base for further optimization. 